### PR TITLE
[1.21] use tags instead of [either, or]

### DIFF
--- a/src/main/resources/data/additional_lights/recipe/fire_for_fire_pit_l.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_for_fire_pit_l.json
@@ -8,14 +8,9 @@
     " #"
     ],
   "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
   },
   "result":{
       "id":"additional_lights:fire_for_fire_pit_l",

--- a/src/main/resources/data/additional_lights/recipe/fire_for_fire_pit_s.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_for_fire_pit_s.json
@@ -8,14 +8,9 @@
     "##"
     ],
   "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
   },
   "result":{
       "id":"additional_lights:fire_for_fire_pit_s",

--- a/src/main/resources/data/additional_lights/recipe/fire_for_standing_torch_l.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_for_standing_torch_l.json
@@ -7,14 +7,9 @@
     "#"
     ],
   "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
   },
   "result":{
       "id":"additional_lights:fire_for_standing_torch_l",

--- a/src/main/resources/data/additional_lights/recipe/fire_for_standing_torch_s.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_for_standing_torch_s.json
@@ -2,7 +2,7 @@
     "type": "minecraft:crafting_shapeless",
     "group": "fire",
     "ingredients": [
-        [ { "item": "minecraft:coal" }, { "item": "minecraft:charcoal" } ]
+        { "tag": "minecraft:coals" }
       ],
     "result":{
         "id":"additional_lights:fire_for_standing_torch_s",

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_cobblestone.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_cut_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_cut_sandstone.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cut_sandstone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_diamond_block.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_diamond_block.json
@@ -7,14 +7,9 @@
     "XX"
   ],
   "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
     ,
     "X": {
       "item": "minecraft:diamond_block"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_end_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_end_stone.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_end_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_end_stone_bricks.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_gold_block.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_gold_block.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:gold_block"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_iron_block.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_iron_block.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:iron_block"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_magenta_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_magenta_wool.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:magenta_wool"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_mossy_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_mossy_cobblestone.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_mossy_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_mossy_stone_bricks.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_nether_bricks.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_packed_ice.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_packed_ice.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:packed_ice"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_pink_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_pink_wool.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:pink_wool"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_andesite.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_andesite.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_andesite"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_blackstone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_blackstone.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_blackstone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_diorite.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_diorite.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_diorite"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_granite.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_polished_granite.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_granite"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_red_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_red_nether_bricks.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:red_nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_sandstone.json
@@ -7,14 +7,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:sandstone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_smooth_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_smooth_stone.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:smooth_stone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_stone.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_l_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_l_stone_bricks.json
@@ -8,14 +8,9 @@
       "XX"
     ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_cobblestone.json
@@ -7,14 +7,9 @@
       "XX"
       ],
     "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_cut_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_cut_sandstone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cut_sandstone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_diamond_block.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_diamond_block.json
@@ -6,14 +6,9 @@
     "XX"
     ],
 "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
     ,
     "X": {
       "item": "minecraft:diamond_block"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_end_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_end_stone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_end_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_end_stone_bricks.json
@@ -7,14 +7,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_gold_block.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_gold_block.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:gold_block"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_iron_block.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_iron_block.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:iron_block"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_magenta_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_magenta_wool.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:magenta_wool"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_mossy_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_mossy_cobblestone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_mossy_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_mossy_stone_bricks.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_nether_bricks.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_packed_ice.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_packed_ice.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:packed_ice"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_pink_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_pink_wool.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:pink_wool"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_andesite.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_andesite.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_andesite"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_blackstone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_blackstone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_blackstone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_diorite.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_diorite.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_diorite"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_granite.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_polished_granite.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_granite"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_red_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_red_nether_bricks.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:red_nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_sandstone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:sandstone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_smooth_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_smooth_stone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:smooth_stone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_stone.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone"

--- a/src/main/resources/data/additional_lights/recipe/fire_pit_s_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/fire_pit_s_stone_bricks.json
@@ -6,14 +6,9 @@
       "XX"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_l.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_l.json
@@ -18,10 +18,7 @@
     ,
     "X": [
       {
-          "item": "minecraft:soul_sand"
-      },
-      {
-          "item": "minecraft:soul_soil"
+          "tag": "minecraft:soul_fire_base_blocks"
       }
   ]
   },

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_l.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_l.json
@@ -7,20 +7,13 @@
     " #"
     ],
 "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
     ,
-    "X": [
-      {
+    "X": {
           "tag": "minecraft:soul_fire_base_blocks"
       }
-  ]
   },
   "result":{
       "id":"additional_lights:soul_fire_for_fire_pit_l",

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_s.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_s.json
@@ -19,10 +19,7 @@
     ,
     "X": [
       {
-          "item": "minecraft:soul_sand"
-      },
-      {
-          "item": "minecraft:soul_soil"
+          "tag": "minecraft:soul_fire_base_blocks"
       }
   ]
   },

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_s.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_fire_pit_s.json
@@ -8,20 +8,13 @@
     "##"
     ],
 "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
     ,
-    "X": [
-      {
+    "X": {
           "tag": "minecraft:soul_fire_base_blocks"
       }
-  ]
   },
   "result":{
       "id":"additional_lights:soul_fire_for_fire_pit_s",

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_standing_torch_l.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_standing_torch_l.json
@@ -6,20 +6,13 @@
     "X#"
     ],
 "key": {
-    "#": [
-      {
-          "item": "minecraft:coal"
-      },
-      {
-          "item": "minecraft:charcoal"
-      }
-  ]
+    "#": {
+          "tag": "minecraft:coals"
+       }
     ,
-    "X": [
-      {
+    "X": {
           "tag": "minecraft:soul_fire_base_blocks"
       }
-  ]
   },
   "result":{
       "id":"additional_lights:soul_fire_for_standing_torch_l",

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_standing_torch_l.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_standing_torch_l.json
@@ -17,10 +17,7 @@
     ,
     "X": [
       {
-          "item": "minecraft:soul_sand"
-      },
-      {
-          "item": "minecraft:soul_soil"
+          "tag": "minecraft:soul_fire_base_blocks"
       }
   ]
   },

--- a/src/main/resources/data/additional_lights/recipe/soul_fire_for_standing_torch_s.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_fire_for_standing_torch_s.json
@@ -2,8 +2,8 @@
     "type": "minecraft:crafting_shapeless",
     "group": "fire",
     "ingredients": [
-        [ { "item": "minecraft:coal" }, { "item": "minecraft:charcoal" } ],
-        [ { "item": "minecraft:soul_sand" }, { "item": "minecraft:soul_soil" } ]
+        { "tag": "minecraft:coals" },
+        { "tag": "minecraft:soul_fire_base_blocks" }
       ],
     "result":{
         "id":"additional_lights:soul_fire_for_standing_torch_s",

--- a/src/main/resources/data/additional_lights/recipe/soul_wand.json
+++ b/src/main/resources/data/additional_lights/recipe/soul_wand.json
@@ -7,7 +7,7 @@
       " / "
       ],
   "key": {
-      "S": [ { "item": "minecraft:soul_sand" }, { "item": "minecraft:soul_soil" } ],
+      "S": { "tag": "minecraft:soul_fire_base_blocks" },
       "/": { "item": "minecraft:stick" },
       "X": { "item": "minecraft:obsidian" },
       "#": { "item": "minecraft:diamond" }

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_cobblestone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_cut_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_cut_sandstone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cut_sandstone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_diamond_block.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_diamond_block.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:diamond_block"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_end_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_end_stone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_end_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_end_stone_bricks.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_gold_block.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_gold_block.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:gold_block"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_iron_block.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_iron_block.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:iron_block"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_magenta_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_magenta_wool.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:magenta_wool"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_mossy_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_mossy_cobblestone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_mossy_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_mossy_stone_bricks.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_nether_bricks.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_packed_ice.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_packed_ice.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:packed_ice"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_pink_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_pink_wool.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:pink_wool"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_andesite.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_andesite.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_andesite"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_blackstone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_blackstone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_blackstone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_diorite.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_diorite.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_diorite"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_granite.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_polished_granite.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_granite"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_red_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_red_nether_bricks.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:red_nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_sandstone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:sandstone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_smooth_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_smooth_stone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:smooth_stone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_stone.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_l_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_l_stone_bricks.json
@@ -7,14 +7,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_cobblestone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_cut_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_cut_sandstone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:cut_sandstone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_diamond_block.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_diamond_block.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:diamond_block"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_end_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_end_stone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_end_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_end_stone_bricks.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:end_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_gold_block.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_gold_block.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:gold_block"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_iron_block.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_iron_block.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:iron_block"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_magenta_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_magenta_wool.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:magenta_wool"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_mossy_cobblestone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_mossy_cobblestone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_cobblestone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_mossy_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_mossy_stone_bricks.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:mossy_stone_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_nether_bricks.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_packed_ice.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_packed_ice.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:packed_ice"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_pink_wool.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_pink_wool.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:pink_wool"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_andesite.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_andesite.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_andesite"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_blackstone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_blackstone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_blackstone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_diorite.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_diorite.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_diorite"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_granite.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_polished_granite.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:polished_granite"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_red_nether_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_red_nether_bricks.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:red_nether_bricks"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_sandstone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_sandstone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:sandstone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_smooth_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_smooth_stone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:smooth_stone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_stone.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_stone.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone"

--- a/src/main/resources/data/additional_lights/recipe/standing_torch_s_stone_bricks.json
+++ b/src/main/resources/data/additional_lights/recipe/standing_torch_s_stone_bricks.json
@@ -6,14 +6,9 @@
       "X"
       ],
   "key": {
-      "#": [
-        {
-            "item": "minecraft:coal"
-        },
-        {
-            "item": "minecraft:charcoal"
+      "#": {
+            "tag": "minecraft:coals"
         }
-    ]
       ,
       "X": {
         "item": "minecraft:stone_bricks"


### PR DESCRIPTION
I only forked 1.21 because it's the version I'm playing, otherwise recipes should be used on all versions
- #coals from 1.14-present
- #soul_fire_base_blocks from 1.16-present